### PR TITLE
Don't add footnotes for bare URLs

### DIFF
--- a/src/LinkRenderer.php
+++ b/src/LinkRenderer.php
@@ -42,8 +42,8 @@ class LinkRenderer implements NodeRendererInterface, ConfigurationAwareInterface
             return $out;
         }
 
-        // Autolink extension makes the label and the URL the same.
-        if ($out === $url) {
+        // Autolink extension makes the label and the unescaped URL the same.
+        if ($out === $node->getUrl()) {
             return '\\url{' . $url . '}';
         }
 

--- a/tests/data/links.md
+++ b/tests/data/links.md
@@ -4,4 +4,4 @@ Relative link: [label](./spaced%20example.html).
 
 Inline URL with angle brackets: <https://example.org>
 
-Bare inline URL: https://example.org
+Bare inline URL: https://example.org/foo_bar

--- a/tests/data/links.tex
+++ b/tests/data/links.tex
@@ -4,5 +4,5 @@ Relative link: label\footnote{\url{./spaced\%20example.html}}.
 
 Inline URL with angle brackets: \url{https://example.org}
 
-Bare inline URL: \url{https://example.org}
+Bare inline URL: \url{https://example.org/foo\_bar}
 


### PR DESCRIPTION
This was the desired behaviour, but it was checking for un-titled links by comparing *after escaping*, so when there were special characters it'd never match and it'd always get a footnote.