### PR TITLE
Add compatibility with the SmartPunctExtension

### DIFF
--- a/src/LatexRendererExtension.php
+++ b/src/LatexRendererExtension.php
@@ -24,6 +24,7 @@ use League\CommonMark\Extension\Footnote\Node\Footnote;
 use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;
 use League\CommonMark\Extension\Footnote\Node\FootnoteContainer;
 use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
+use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;
 use League\CommonMark\Node\Block\Paragraph;
 use League\CommonMark\Node\Inline\Text;
 use Samwilson\CommonMarkLatex\Footnotes\FootnoteBackrefRenderer;
@@ -31,6 +32,10 @@ use Samwilson\CommonMarkLatex\Footnotes\FootnoteContainerRenderer;
 use Samwilson\CommonMarkLatex\Footnotes\FootnoteRefRenderer;
 use Samwilson\CommonMarkLatex\Footnotes\FootnoteRenderer;
 use Samwilson\CommonMarkLatex\Footnotes\GatherFootnotesListener;
+use Samwilson\CommonMarkLatex\SmartPunct\EllipsesParser;
+use Samwilson\CommonMarkLatex\SmartPunct\QuoteParser;
+use Samwilson\CommonMarkLatex\SmartPunct\QuoteProcessor;
+use Samwilson\CommonMarkLatex\SmartPunct\ReplaceUnpairedQuotesListener;
 
 final class LatexRendererExtension implements ExtensionInterface
 {
@@ -64,9 +69,19 @@ final class LatexRendererExtension implements ExtensionInterface
                     ->addRenderer(FootnoteRef::class, new FootnoteRefRenderer(), 15)
                     ->addRenderer(Footnote::class, new FootnoteRenderer(), 15)
                     ->addEventListener(DocumentParsedEvent::class, [new GatherFootnotesListener(), 'onDocumentParsed'], 15);
+            }
 
-                return;
+            if ($ext instanceof SmartPunctExtension) {
+                throw new \Exception('The SmartPunctExtension should not be enabled at the same time as the LatexRendererExtension');
             }
         }
+
+        // SmartPunct extension replication.
+        $environment
+            ->addInlineParser(new QuoteParser(), 10)
+            ->addInlineParser(new EllipsesParser(), 15)
+            ->addDelimiterProcessor(QuoteProcessor::createDoubleQuoteProcessor())
+            ->addDelimiterProcessor(QuoteProcessor::createSingleQuoteProcessor())
+            ->addEventListener(DocumentParsedEvent::class, new ReplaceUnpairedQuotesListener());
     }
 }

--- a/src/SmartPunct/EllipsesParser.php
+++ b/src/SmartPunct/EllipsesParser.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is almost entirely duplicated from the CommonMark core package.
+ */
+
+declare(strict_types=1);
+
+namespace Samwilson\CommonMarkLatex\SmartPunct;
+
+use League\CommonMark\Node\Inline\Text;
+use League\CommonMark\Parser\Inline\InlineParserInterface;
+use League\CommonMark\Parser\Inline\InlineParserMatch;
+use League\CommonMark\Parser\InlineParserContext;
+
+final class EllipsesParser implements InlineParserInterface
+{
+    public function getMatchDefinition(): InlineParserMatch
+    {
+        return InlineParserMatch::oneOf('...', '. . .');
+    }
+
+    public function parse(InlineParserContext $inlineContext): bool
+    {
+        $inlineContext->getCursor()->advanceBy($inlineContext->getFullMatchLength());
+        $inlineContext->getContainer()->appendChild(new Text('\dots'));
+
+        return true;
+    }
+}

--- a/src/SmartPunct/Quote.php
+++ b/src/SmartPunct/Quote.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Samwilson\CommonMarkLatex\SmartPunct;
+
+use League\CommonMark\Node\Inline\AbstractStringContainer;
+
+final class Quote extends AbstractStringContainer
+{
+    public const DOUBLE_QUOTE        = '"';
+    public const DOUBLE_QUOTE_OPENER = '``';
+    public const DOUBLE_QUOTE_CLOSER = "''";
+
+    public const SINGLE_QUOTE        = "'";
+    public const SINGLE_QUOTE_OPENER = '`';
+    public const SINGLE_QUOTE_CLOSER = "'";
+}

--- a/src/SmartPunct/QuoteParser.php
+++ b/src/SmartPunct/QuoteParser.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is entirely duplicated from the CommonMark core package.
+ */
+
+declare(strict_types=1);
+
+namespace Samwilson\CommonMarkLatex\SmartPunct;
+
+use League\CommonMark\Delimiter\Delimiter;
+use League\CommonMark\Parser\Inline\InlineParserInterface;
+use League\CommonMark\Parser\Inline\InlineParserMatch;
+use League\CommonMark\Parser\InlineParserContext;
+use League\CommonMark\Util\RegexHelper;
+
+final class QuoteParser implements InlineParserInterface
+{
+    /**
+     * @deprecated This constant is no longer used and will be removed in a future major release
+     */
+    public const DOUBLE_QUOTES = [Quote::DOUBLE_QUOTE, Quote::DOUBLE_QUOTE_OPENER, Quote::DOUBLE_QUOTE_CLOSER];
+
+    /**
+     * @deprecated This constant is no longer used and will be removed in a future major release
+     */
+    public const SINGLE_QUOTES = [Quote::SINGLE_QUOTE, Quote::SINGLE_QUOTE_OPENER, Quote::SINGLE_QUOTE_CLOSER];
+
+    public function getMatchDefinition(): InlineParserMatch
+    {
+        return InlineParserMatch::oneOf(Quote::SINGLE_QUOTE, Quote::DOUBLE_QUOTE);
+    }
+
+    /**
+     * Normalizes any quote characters found and manually adds them to the delimiter stack
+     */
+    public function parse(InlineParserContext $inlineContext): bool
+    {
+        $char   = $inlineContext->getFullMatch();
+        $cursor = $inlineContext->getCursor();
+        $index  = $cursor->getPosition();
+
+        $charBefore = $cursor->peek(-1);
+        if ($charBefore === null) {
+            $charBefore = "\n";
+        }
+
+        $cursor->advance();
+
+        $charAfter = $cursor->getCurrentCharacter();
+        if ($charAfter === null) {
+            $charAfter = "\n";
+        }
+
+        [$leftFlanking, $rightFlanking] = $this->determineFlanking($charBefore, $charAfter);
+        $canOpen                        = $leftFlanking && ! $rightFlanking;
+        $canClose                       = $rightFlanking;
+
+        $node = new Quote($char, ['delim' => true]);
+        $inlineContext->getContainer()->appendChild($node);
+
+        // Add entry to stack to this opener
+        $inlineContext->getDelimiterStack()->push(new Delimiter($char, 1, $node, $canOpen, $canClose, $index));
+
+        return true;
+    }
+
+    /**
+     * @return bool[]
+     */
+    private function determineFlanking(string $charBefore, string $charAfter): array
+    {
+        $afterIsWhitespace   = \preg_match('/\pZ|\s/u', $charAfter);
+        $afterIsPunctuation  = \preg_match(RegexHelper::REGEX_PUNCTUATION, $charAfter);
+        $beforeIsWhitespace  = \preg_match('/\pZ|\s/u', $charBefore);
+        $beforeIsPunctuation = \preg_match(RegexHelper::REGEX_PUNCTUATION, $charBefore);
+
+        $leftFlanking = ! $afterIsWhitespace &&
+            ! ($afterIsPunctuation &&
+                ! $beforeIsWhitespace &&
+                ! $beforeIsPunctuation);
+
+        $rightFlanking = ! $beforeIsWhitespace &&
+            ! ($beforeIsPunctuation &&
+                ! $afterIsWhitespace &&
+                ! $afterIsPunctuation);
+        //echo "$charAfter, right = $rightFlanking, left = $leftFlanking\n";
+
+        return [$leftFlanking, $rightFlanking];
+    }
+}

--- a/src/SmartPunct/QuoteProcessor.php
+++ b/src/SmartPunct/QuoteProcessor.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is entirely duplicated from the CommonMark core package.
+ */
+
+declare(strict_types=1);
+
+namespace Samwilson\CommonMarkLatex\SmartPunct;
+
+use League\CommonMark\Delimiter\DelimiterInterface;
+use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Node\Inline\AbstractStringContainer;
+
+final class QuoteProcessor implements DelimiterProcessorInterface
+{
+    /** @psalm-readonly */
+    private string $normalizedCharacter;
+
+    /** @psalm-readonly */
+    private string $openerCharacter;
+
+    /** @psalm-readonly */
+    private string $closerCharacter;
+
+    private function __construct(string $char, string $opener, string $closer)
+    {
+        $this->normalizedCharacter = $char;
+        $this->openerCharacter     = $opener;
+        $this->closerCharacter     = $closer;
+    }
+
+    public function getOpeningCharacter(): string
+    {
+        return $this->normalizedCharacter;
+    }
+
+    public function getClosingCharacter(): string
+    {
+        return $this->normalizedCharacter;
+    }
+
+    public function getMinLength(): int
+    {
+        return 1;
+    }
+
+    public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int
+    {
+        return 1;
+    }
+
+    public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse): void
+    {
+        $opener->insertAfter(new Quote($this->openerCharacter));
+        $closer->insertBefore(new Quote($this->closerCharacter));
+    }
+
+    /**
+     * Create a double-quote processor
+     */
+    public static function createDoubleQuoteProcessor(string $opener = Quote::DOUBLE_QUOTE_OPENER, string $closer = Quote::DOUBLE_QUOTE_CLOSER): self
+    {
+        return new self(Quote::DOUBLE_QUOTE, $opener, $closer);
+    }
+
+    /**
+     * Create a single-quote processor
+     */
+    public static function createSingleQuoteProcessor(string $opener = Quote::SINGLE_QUOTE_OPENER, string $closer = Quote::SINGLE_QUOTE_CLOSER): self
+    {
+        return new self(Quote::SINGLE_QUOTE, $opener, $closer);
+    }
+}

--- a/src/SmartPunct/ReplaceUnpairedQuotesListener.php
+++ b/src/SmartPunct/ReplaceUnpairedQuotesListener.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is entirely duplicated from the CommonMark core package.
+ */
+
+declare(strict_types=1);
+
+namespace Samwilson\CommonMarkLatex\SmartPunct;
+
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Node\Inline\AdjacentTextMerger;
+use League\CommonMark\Node\Inline\Text;
+use League\CommonMark\Node\Query;
+
+/**
+ * Identifies any lingering Quote nodes that were missing pairs and converts them into Text nodes
+ */
+final class ReplaceUnpairedQuotesListener
+{
+    public function __invoke(DocumentParsedEvent $event): void
+    {
+        $query = (new Query())->where(Query::type(Quote::class));
+        foreach ($query->findAll($event->getDocument()) as $quote) {
+            \assert($quote instanceof Quote);
+
+            $literal = $quote->getLiteral();
+            if ($literal === Quote::SINGLE_QUOTE) {
+                $literal = Quote::SINGLE_QUOTE_CLOSER;
+            } elseif ($literal === Quote::DOUBLE_QUOTE) {
+                $literal = Quote::DOUBLE_QUOTE_OPENER;
+            }
+
+            $quote->replaceWith($new = new Text($literal));
+            AdjacentTextMerger::mergeWithDirectlyAdjacentNodes($new);
+        }
+    }
+}

--- a/tests/data/headlines.md
+++ b/tests/data/headlines.md
@@ -1,7 +1,7 @@
 Head 1
 ======
 
-Lorem ipsum...
+Lorem ipsum
 
 ## Head 2
 

--- a/tests/data/headlines.tex
+++ b/tests/data/headlines.tex
@@ -1,5 +1,5 @@
 \section{Head 1}
-Lorem ipsum...
+Lorem ipsum
 
 \subsection{Head 2}
 Dolor!

--- a/tests/data/smart_punct.md
+++ b/tests/data/smart_punct.md
@@ -1,0 +1,5 @@
+This is "double quoted" and --- this is 'single quoted'.
+
+Ellipsis can be spaced . . . or not...
+
+Possessive's apostrophes are fine, as are '80s-style prefixed ones.

--- a/tests/data/smart_punct.md
+++ b/tests/data/smart_punct.md
@@ -2,4 +2,4 @@ This is "double quoted" and --- this is 'single quoted'.
 
 Ellipsis can be spaced . . . or not...
 
-Possessive's apostrophes are fine, as are '80s-style prefixed ones.
+Possessive's apostrophes are fine, as are prefixed ones like '80s.

--- a/tests/data/smart_punct.tex
+++ b/tests/data/smart_punct.tex
@@ -1,0 +1,6 @@
+This is ``double quoted'' and --- this is `single quoted'.
+
+Ellipsis can be spaced \dots or not\dots
+
+Possessive's apostrophes are fine, as are '80s-style prefixed ones.
+

--- a/tests/data/smart_punct.tex
+++ b/tests/data/smart_punct.tex
@@ -2,5 +2,5 @@ This is ``double quoted'' and --- this is `single quoted'.
 
 Ellipsis can be spaced \dots or not\dots
 
-Possessive's apostrophes are fine, as are '80s-style prefixed ones.
+Possessive's apostrophes are fine, as are prefixed ones like '80s.
 


### PR DESCRIPTION
This duplicates most of the code from the SmartPunctExtension in order to make it work for LaTeX-style quotes and ellipses and to remove its handling of dashes.

Ideally most of these classes would be able to extend their SmartPunctExtension counterparts, but those are `final` and so this is the hacky workaround.

Refs #12